### PR TITLE
Details

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,10 +10,6 @@ var _request = require('request');
 
 var _request2 = _interopRequireDefault(_request);
 
-var _lodash = require('lodash');
-
-var _lodash2 = _interopRequireDefault(_lodash);
-
 var _v = require('uuid/v4');
 
 var _v2 = _interopRequireDefault(_v);
@@ -26,8 +22,9 @@ var Analytics = function () {
   /**
    * Class constructor
    */
-  function Analytics(trackingID, _ref) {
-    var _ref$userAgent = _ref.userAgent,
+  function Analytics(trackingID) {
+    var _ref = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
+        _ref$userAgent = _ref.userAgent,
         userAgent = _ref$userAgent === undefined ? '' : _ref$userAgent,
         _ref$debug = _ref.debug,
         debug = _ref$debug === undefined ? false : _ref$debug,
@@ -259,7 +256,7 @@ var Analytics = function () {
           cid: clientID || (0, _v2.default)(),
           t: hitType
         };
-        if (params) _lodash2.default.extend(formObj, params);
+        if (params) Object.assign(formObj, params);
 
         var url = '' + _this._baseURL + _this._collectURL;
         if (_this._debug) {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "mocha": "^3.2.0"
   },
   "dependencies": {
-    "lodash": "^4.17.4",
     "request": "^2.79.0",
     "uuid": "^3.0.1"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,11 @@
 import request from 'request';
-import _ from 'lodash';
 import uuidV4 from 'uuid/v4';
 
 class Analytics {
   /**
    * Class constructor
    */
-  constructor(trackingID, { userAgent = '', debug = false, version = 1 }) {
+  constructor(trackingID, { userAgent = '', debug = false, version = 1 } = {}) {
     // Debug
     this._debug = debug;
 
@@ -248,7 +247,7 @@ class Analytics {
         cid: clientID || uuidV4(),
         t: hitType
       };
-      if (params) _.extend(formObj, params);
+      if (params) Object.assign(formObj, params);
 
       let url = `${this._baseURL}${this._collectURL}`;
       if (this._debug) {


### PR DESCRIPTION
Hello,
Just corrected a small forgotten default on the object being deconstructed in Analytics constructor arguments, which BTW led to your example code not being possible to use

```javascript
import Analytics from 'electron-google-analytics';
const analytics = new Analytics('UA-XXXXXXXX-X'); // would fail
const analytics = new Analytics('UA-XXXXXXXX-X', {}); // would not fail
```

Now these both work.

Plus I removed the dependency on Lodash, which was used only once for doing `_.extend`. I replaced that with `Object.assign`. 