### PR TITLE
Add es5 instructions to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ npm i electron-google-analytics
 If you are not using tools like babel to use es6 with your application, you'll have to modify your code slightly. Below is an example of a test screen view that you can use out of the box with node.js
 ```
 const Analytics  = require('electron-google-analytics');
-const analytics = new Analytics.default('UA-57939776-2');
+const analytics = new Analytics.default('UA-XXXXXXXX-X');
 
 function test(){
     return analytics.screen('test', '1.0.0', 'com.app.test', 'com.app.installer', 'Test')

--- a/README.md
+++ b/README.md
@@ -145,7 +145,22 @@ npm i electron-google-analytics
       return err;
     });
   ```
+#### es5 usage
+If you are not using tools like babel to use es6 with your application, you'll have to modify your code slightly. Below is an example of a test screen view that you can use out of the box with node.js
+```
+const Analytics  = require('electron-google-analytics');
+const analytics = new Analytics.default('UA-57939776-2');
 
+function test(){
+    return analytics.screen('test', '1.0.0', 'com.app.test', 'com.app.installer', 'Test')
+  .then((response) => {
+    return response;
+  }).catch((err) => {
+    return err;
+  });
+}
+test();
+```
 #### Tests
 ```
 cross-env TRACKING_ID='UA-XXXXXXXX-X' npm test


### PR DESCRIPTION
I'm not using es6 in my application, and my integration with this package got about as far as the first `import` statement. This will hopefully open the package up to people who are using it with less complex build flows.