### PR TITLE
Alternative module loading method in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ npm i electron-google-analytics
     `Analytics(trackingID, { userAgent, debug, version })`
     ```javascript
     import Analytics from 'electron-google-analytics';
+    //OR: let Analytics = require('electron-google-analytics').default;
     const analytics = new Analytics('UA-XXXXXXXX-X');
     ```
 * Set (custom params)


### PR DESCRIPTION
Using "require" may have better compatibility than "import" so it is not a bad idea to mention it.