### PR TITLE
Fixed mistake in readme about pageview arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ npm i electron-google-analytics
 
 * Pageview
 
-  `Analytics#pageview(hostname, url, title, clientID)`
+  `Analytics#pageview(hostname, url, title, sessionDuration, clientID)`
   ```javascript
   return analytics.pageview('http://example.com', '/home', 'Example')
     .then((response) => {
@@ -60,7 +60,7 @@ npm i electron-google-analytics
       return err;
     });
   ```
-  If you want to keep the session you need to specify the `clientID`.
+  If you want to keep the session you need to specify the `clientID`. The `clientID` can be found in the promise `response` above.
 
 * Event
 


### PR DESCRIPTION
Looking at the source, `pageview` has also a session duration argument that is missed in the readme. Adding it fixed my problem: I couldn't get the clientID to work because it was not in the right argument place.

I used `undefined` without any issues. Can you please explain what is the right thing to put for the session duration?

(also clarified how `clientID` is found)