### PR TITLE
Add Electron networking support

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,14 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "babel src -d lib",
-    "test": "cross-env NODE_ENV=test mocha --compilers js:babel-register"
+    "test": "cross-env NODE_ENV=test mocha --require babel-register",
+    "test-electron": "cross-env NODE_ENV=test USE_ELECTRON_NET=true electron-mocha --require babel-register"
   },
   "keywords": [
     "google",
     "analytics",
-    "google analytics"
+    "google analytics",
+    "electron"
   ],
   "author": "Eastercow <eastercowz@gmail.com> (http://eastercowz.com)",
   "license": "MIT",
@@ -26,13 +28,19 @@
     "babel-register": "^6.26.0",
     "chai": "^4.1.2",
     "cross-env": "^5.1.4",
+    "electron": ">2.0",
+    "electron-mocha": "^5.0.0",
     "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.10.0",
     "mocha": "^5.0.5"
   },
   "dependencies": {
+    "form-urlencoded": "^3.0.0",
     "request": "^2.85.0",
     "uuid": "^3.2.1"
+  },
+  "peerDependencies": {
+    "electron": ">2.0"
   }
 }

--- a/src/electron-adapter.js
+++ b/src/electron-adapter.js
@@ -1,0 +1,75 @@
+import { net } from 'electron';
+import formurlencoded from 'form-urlencoded';
+
+function copyResponse(response) {
+  const { headers, statusCode } = response;
+  const contentType = headers['content-type'][0];
+  headers['content-type'] = contentType;
+  return {
+    statusCode,
+    headers
+  };
+}
+
+function post(options, requestCallback, electronOpts) {
+  const { url, form } = options;
+  const { partition, session } = electronOpts;
+
+  const formString = formurlencoded(form);
+  const headers = options.headers || {};
+  headers['content-type'] = 'application/x-www-form-urlencoded';
+  headers['content-length'] = formString.length;
+
+  try {
+    const req = net.request({
+      headers,
+      method: 'POST',
+      url,
+      session,
+      partition
+    });
+
+    return new Promise((resolve, reject) => {
+      req.on('response', (response) => {
+        const chunks = [];
+
+        response.on('data', (chunk) => {
+          chunks.push(chunk);
+        });
+
+        response.on('error', (error) => {
+          requestCallback(error, copyResponse(response));
+          reject(error);
+        });
+
+        response.on('end', () => {
+          const body = Buffer.concat(chunks).toString('utf8');
+          try {
+            requestCallback(null, copyResponse(response), body);
+          } catch (error) {
+            requestCallback(error);
+            reject(error);
+          }
+          resolve(body);
+        });
+      });
+
+      req.on('error', (error) => {
+        requestCallback(error);
+        reject(error);
+      });
+
+      req.write(formString);
+      req.end();
+    });
+  } catch (error) {
+    requestCallback(error);
+    return Promise.reject(error);
+  }
+}
+
+export default function electronAdapter(electronOpts) {
+  return {
+    post: (options, requestCallback) => post(options, requestCallback, electronOpts)
+  };
+}

--- a/test/electron-adapter.js
+++ b/test/electron-adapter.js
@@ -1,0 +1,84 @@
+import * as http from 'http';
+import chai from 'chai';
+
+const expect = chai.expect;
+
+describe('Electron adapter', () => {
+  if (process.env.USE_ELECTRON_NET) {
+    const adapter = require('../lib/electron-adapter');
+
+    let server;
+    const connections = new Set();
+
+    beforeEach((done) => {
+      server = http.createServer();
+      server.listen(0, '127.0.0.1', () => {
+        server.url = `http://127.0.0.1:${server.address().port}`;
+        done();
+      });
+      server.on('connection', (connection) => {
+        connections.add(connection);
+        connection.once('close', () => {
+          connections.delete(connection);
+        });
+      });
+    });
+
+    afterEach((done) => {
+      for (const connection of connections) {
+        connection.destroy();
+      }
+      server.close(() => {
+        server = null;
+        done();
+      });
+    });
+
+    it('should post the correct form data', (done) => {
+      const requestUrl = '/requestUrl';
+      const bodyData = 'v=1&t=pageview&dh=http%3A%2F%2Fexample.com&dp=%2Ftest&dt=Test';
+
+      server.on('request', (request, response) => {
+        let postedBodyData = '';
+        expect(request.url).to.equal(requestUrl);
+        expect(request.method).to.equal('POST');
+
+        request.on('data', (chunk) => {
+          postedBodyData += chunk.toString();
+        });
+
+        request.on('end', () => {
+          expect(postedBodyData).to.equal(bodyData);
+
+          response.statusCode = 200;
+          response.setHeader('content-type', 'application/json');
+          response.write('response');
+          response.end();
+        });
+      });
+
+      const form = {
+        v: 1,
+        t: 'pageview',
+        dh: 'http://example.com',
+        dp: '/test',
+        dt: 'Test'
+      };
+
+      const request = adapter.default({});
+      request.post(
+        {
+          url: `${server.url}${requestUrl}`,
+          form
+        },
+        (err, response, body) => {
+          expect(err).to.equal(null);
+          expect(response.headers['content-type']).to.equal('application/json');
+          expect(response.statusCode).to.equal(200);
+          expect(body).to.equal('response');
+          done();
+        }
+      );
+    });
+  }
+});

--- a/test/index.js
+++ b/test/index.js
@@ -3,11 +3,12 @@ import Analytics from '../src/index';
 
 const expect = chai.expect;
 const trackingID = (process.env.TRACKING_ID) ? process.env.TRACKING_ID : '';
+const electronOpts = { useElectronNet: process.env.USE_ELECTRON_NET };
 
 describe('Analytics', function() {
   if (trackingID) {
     it('should send a pageview request', function() {
-      const analytics = new Analytics(trackingID, { debug: true });
+      const analytics = new Analytics(trackingID, { debug: true, electronOpts });
 
       return analytics.pageview('http://example.com', '/test', 'Test')
         .then((response) => {
@@ -18,7 +19,7 @@ describe('Analytics', function() {
     });
 
     it('should send a event request', function() {
-      const analytics = new Analytics(trackingID, { debug: true });
+      const analytics = new Analytics(trackingID, { debug: true, electronOpts });
 
       return analytics.event('category', 'view').then((response) => {
         return expect(response).to.have.property('clientID');
@@ -28,7 +29,7 @@ describe('Analytics', function() {
     });
 
     it('should send a screenview request', function() {
-      const analytics = new Analytics(trackingID, { debug: true });
+      const analytics = new Analytics(trackingID, { debug: true, electronOpts });
 
       return analytics.screen('test', '1.0.0', 'com.app.test', 'com.app.installer', 'Test')
         .then((response) => {
@@ -39,7 +40,7 @@ describe('Analytics', function() {
     });
 
     it('should send a transaction request', function() {
-      const analytics = new Analytics(trackingID, { debug: true });
+      const analytics = new Analytics(trackingID, { debug: true, electronOpts });
 
       return analytics.transaction(123).then((response) => {
         return expect(response).to.have.property('clientID');
@@ -49,7 +50,7 @@ describe('Analytics', function() {
     });
 
     it('should send a social request', function() {
-      const analytics = new Analytics(trackingID, { debug: true });
+      const analytics = new Analytics(trackingID, { debug: true, electronOpts });
 
       return analytics.social('like', 'facebook', 'home').then((response) => {
         return expect(response).to.have.property('clientID');
@@ -59,7 +60,7 @@ describe('Analytics', function() {
     });
 
     it('should send a exception request', function() {
-      const analytics = new Analytics(trackingID, { debug: true });
+      const analytics = new Analytics(trackingID, { debug: true, electronOpts });
 
       return analytics.exception('IOException', 1).then((response) => {
         return expect(response).to.have.property('clientID');
@@ -69,7 +70,7 @@ describe('Analytics', function() {
     });
 
     it('should send a refund request', function() {
-      const analytics = new Analytics(trackingID, { debug: true });
+      const analytics = new Analytics(trackingID, { debug: true, electronOpts });
 
       return analytics.refund('T123').then((response) => {
         return expect(response).to.have.property('clientID');
@@ -79,7 +80,7 @@ describe('Analytics', function() {
     });
 
     it('should send a purchase request', function() {
-      const analytics = new Analytics(trackingID, { debug: true });
+      const analytics = new Analytics(trackingID, { debug: true, electronOpts });
 
       return analytics.purchase('http://example.com', '/test', 'Test', 'T123', { prdID: 'P123' })
         .then((response) => {
@@ -90,7 +91,7 @@ describe('Analytics', function() {
     });
 
     it('should send a checkout request', function() {
-      const analytics = new Analytics(trackingID, { debug: true });
+      const analytics = new Analytics(trackingID, { debug: true, electronOpts });
 
       return analytics.checkout('http://example.com', '/test', 'Test', '1', 'Visa')
         .then((response) => {
@@ -101,7 +102,7 @@ describe('Analytics', function() {
     });
 
     it('should send a checkoutOpt request', function() {
-      const analytics = new Analytics(trackingID, { debug: true });
+      const analytics = new Analytics(trackingID, { debug: true, electronOpts });
 
       return analytics.checkoutOpt('Checkout', 'Option', '2', 'FedEx')
         .then((response) => {
@@ -112,7 +113,7 @@ describe('Analytics', function() {
     });
 
     it('should send a item request', function() {
-      const analytics = new Analytics(trackingID, { debug: true });
+      const analytics = new Analytics(trackingID, { debug: true, electronOpts });
 
       return analytics.item(123, 'Test item').then((response) => {
         return expect(response).to.have.property('clientID');
@@ -122,7 +123,7 @@ describe('Analytics', function() {
     });
 
     it('should send a timing tracking request', function() {
-      const analytics = new Analytics(trackingID, { debug: true });
+      const analytics = new Analytics(trackingID, { debug: true, electronOpts });
 
       return analytics.timingTrk('Category', 'jsonLoader').then((response) => {
         return expect(response).to.have.property('clientID');
@@ -132,7 +133,7 @@ describe('Analytics', function() {
     });
 
     it('should send a custom request', function() {
-      const analytics = new Analytics(trackingID, { debug: true });
+      const analytics = new Analytics(trackingID, { debug: true, electronOpts });
 
       return analytics.send('social', { sa: 'social', sn: 'facebook', st: 'home' })
         .then((response) => {
@@ -145,7 +146,7 @@ describe('Analytics', function() {
 
 
   it('should fail sending a pageview request', function() {
-    const analytics = new Analytics('', { debug: true });
+    const analytics = new Analytics('', { debug: true, electronOpts });
 
     return analytics.pageview('http://example.com', 'test', 'test')
       .then((response) => {
@@ -156,7 +157,7 @@ describe('Analytics', function() {
   });
 
   it('should fail sending a event request', function() {
-    const analytics = new Analytics('', { debug: true });
+    const analytics = new Analytics('', { debug: true, electronOpts });
 
     return analytics.event('category', 'view').then((response) => {
       return expect(response).to.be.empty;
@@ -166,7 +167,7 @@ describe('Analytics', function() {
   });
 
   it('should fail sending a screenview request', function() {
-    const analytics = new Analytics('', { debug: true });
+    const analytics = new Analytics('', { debug: true, electronOpts });
 
     return analytics.screen('test', '1.0.0', 'com.app.test', 'com.app.installer', 'Test')
       .then((response) => {
@@ -177,7 +178,7 @@ describe('Analytics', function() {
   });
 
   it('should fail sending a transaction request', function() {
-    const analytics = new Analytics('', { debug: true });
+    const analytics = new Analytics('', { debug: true, electronOpts });
 
     return analytics.transaction(123).then((response) => {
       return expect(response).to.be.empty;
@@ -187,7 +188,7 @@ describe('Analytics', function() {
   });
 
   it('should fail sending a social request', function() {
-    const analytics = new Analytics('', { debug: true });
+    const analytics = new Analytics('', { debug: true, electronOpts });
 
     return analytics.social('like', 'facebook', 'home').then((response) => {
       return expect(response).to.be.empty;
@@ -197,7 +198,7 @@ describe('Analytics', function() {
   });
 
   it('should fail sending a exception request', function() {
-    const analytics = new Analytics('', { debug: true });
+    const analytics = new Analytics('', { debug: true, electronOpts });
 
     return analytics.exception('IOException', 1).then((response) => {
       return expect(response).to.be.empty;
@@ -207,7 +208,7 @@ describe('Analytics', function() {
   });
 
   it('should fail sending a refund request', function() {
-    const analytics = new Analytics('', { debug: true });
+    const analytics = new Analytics('', { debug: true, electronOpts });
 
     return analytics.refund('T123').then((response) => {
       return expect(response).to.be.empty;
@@ -217,7 +218,7 @@ describe('Analytics', function() {
   });
 
   it('should fail sending a purchase request', function() {
-    const analytics = new Analytics('', { debug: true });
+    const analytics = new Analytics('', { debug: true, electronOpts });
 
     return analytics.purchase('http://example.com', '/test', 'Test', 'T123', { prdID: 'P123' })
       .then((response) => {
@@ -228,7 +229,7 @@ describe('Analytics', function() {
   });
 
   it('should fail sending a checkout request', function() {
-    const analytics = new Analytics('', { debug: true });
+    const analytics = new Analytics('', { debug: true, electronOpts });
 
     return analytics.checkout('http://example.com', '/test', 'Test', '1', 'Visa')
       .then((response) => {
@@ -239,7 +240,7 @@ describe('Analytics', function() {
   });
 
   it('should fail sending a checkoutOpt request', function() {
-    const analytics = new Analytics('', { debug: true });
+    const analytics = new Analytics('', { debug: true, electronOpts });
 
     return analytics.checkoutOpt('Checkout', 'Option', '2', 'FedEx')
       .then((response) => {
@@ -250,7 +251,7 @@ describe('Analytics', function() {
   });
 
   it('should fail sending a item request', function() {
-    const analytics = new Analytics('', { debug: true });
+    const analytics = new Analytics('', { debug: true, electronOpts });
 
     return analytics.item(123, 'Test item').then((response) => {
       return expect(response).to.be.empty;
@@ -260,7 +261,7 @@ describe('Analytics', function() {
   });
 
   it('should fail sending a timing tracking request', function() {
-    const analytics = new Analytics('', { debug: true });
+    const analytics = new Analytics('', { debug: true, electronOpts });
 
     return analytics.timingTrk('Category', 'jsonLoader').then((response) => {
       return expect(response).to.be.empty;
@@ -270,7 +271,7 @@ describe('Analytics', function() {
   });
 
   it('should fail sending a custom request', function() {
-    const analytics = new Analytics('', { debug: true });
+    const analytics = new Analytics('', { debug: true, electronOpts });
 
     return analytics.send('social', { sa: 'social', sn: 'facebook', st: 'home' })
       .then((response) => {


### PR DESCRIPTION
Add option to use [Electron net API](https://electronjs.org/docs/api/net) instead of `request` HTTP client. Passing session/partition parameter to `net.request()` allows to reuse web proxy configuration within Electron application.

Example:
```js
import {session} from 'electron';
import Analytics from 'electron-google-analytics';

const sessionObj = session.fromPartition('persist:proxy');
sessionObj.setProxy({proxyRules:"foo.bar:8080"}

const analytics = new Analytics('UA-XXXXXXXX-X', {electronOpts: {useElectronNet: true, partition: 'persist:proxy'}});
```
